### PR TITLE
fix: 修正注释文件函数名拼写错误

### DIFF
--- a/src/Bot.d.ts
+++ b/src/Bot.d.ts
@@ -115,7 +115,7 @@ export class Bot implements BotConfigGetable {
      * @description 移除所有事件处理器
      * @param eventType 可选，事件类型(或数组)
      */
-    ofAll(eventType?: EventType | EventType[]): void;
+    offAll(eventType?: EventType | EventType[]): void;
 
     /**
      * @description 获取 config


### PR DESCRIPTION
# 问题说明
`src/Bot.d.ts` 中 `Bot.offAll` 方法错误拼写成了 `ofAll`。
# 问题影响
- `Bot.offAll` 方法没有JSDoc描述。
- `ofAll` 在编辑器上被错误用于代码补全。
- （高严重性）若使用 Typescript 进行编程，则 `Bot.offAll` 方法完全不可用。
# PR说明
修正 `ofAll` 为 `offAll`。