### PR TITLE
修正注释文件错误：addForwardNode返回类型错误

### DIFF
--- a/src/Message.d.ts
+++ b/src/Message.d.ts
@@ -58,8 +58,8 @@ export class ForwardMessage implements MessageChainGetable {
         time,
         senderName,
         messageChain
-    }: ForwardNode): Message;
-    addForwardNode(messageId: MessageId): ForwardMessage;
+    }: ForwardNode): this;
+    addForwardNode(messageId: MessageId): this;
 
     // implements MessageChainGetable
     getMessageChain(): MessageType[];


### PR DESCRIPTION
# 问题
- 在`src/Message.d.ts`中，`ForwardMessage.addForwardNode`的返回类型错误。
# 影响
- 在Javascript开发环境中，调用`addForwardNode(... as ForwardNode)`后的自动补全提示错误。
- 在Typescript开发环境中，无法在调用`addForwardNode(... as ForwardNode)`后继续进行对原对象的链式调用，因为错误地返回了`Message`。
# 修正
将错误的返回类型`Message`改为正确的`this`。同时，将下一行的`ForwardMessage`也同时变更为了`this`（对于Builder链式调用，返回值注`this`的可读性更高）。
# 注意
**仅修正了`src/Message.d.ts`，需手动同步至`dist/node/Message.d.ts`。**